### PR TITLE
Use yum priorities so Delorean RPMs are preferred

### DIFF
--- a/delorean/shell.py
+++ b/delorean/shell.py
@@ -377,7 +377,7 @@ def build(cp, package_info, commit, env_vars):
 
     fp = open(os.path.join(yumrepodir_abs, "delorean.repo"), "w")
     fp.write("[delorean]\nname=delorean-%s-%s\nbaseurl=%s/%s\nenabled=1\n"
-             "gpgcheck=0" % (project_name, commit_hash,
+             "gpgcheck=0\npriority=1" % (project_name, commit_hash,
                              cp.get("DEFAULT", "baseurl"), yumrepodir))
     fp.close()
 

--- a/scripts/build_rpm.sh
+++ b/scripts/build_rpm.sh
@@ -70,7 +70,7 @@ cd ~/rpmbuild/SPECS/
 
 # Add the mostcurrent repo, we may have dependencies in it
 if [ -e /data/repos/current/repodata ] ; then
-    echo -e '[current]\nname=current\nbaseurl=file:///data/repos/current\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/current.repo
+    echo -e '[current]\nname=current\nbaseurl=file:///data/repos/current\nenabled=1\ngpgcheck=0\npriority=1' > /etc/yum.repos.d/current.repo
 fi
 
 sed -i -e "s/UPSTREAMVERSION/$UPSTREAMVERSION/g" *.spec

--- a/scripts/update_image.sh
+++ b/scripts/update_image.sh
@@ -2,6 +2,6 @@
 
 yum clean all
 yum update -y --nogpg
-yum install -y --nogpg rpm-build git python-setuptools yum-utils python2-devel intltool make python-pip gcc
+yum install -y --nogpg rpm-build git python-setuptools yum-utils python2-devel intltool make python-pip gcc yum-plugin-priorities
 # temp deps
 yum install -y --nogpg python-sqlalchemy python-webob python-eventlet ghostscript graphviz python-sphinx 


### PR DESCRIPTION
Updates Delorean so that the Yum priorities plugin
can be used to ensure Delorean repo RPMs are always
preferred.
