### PR TITLE
Resolving confusion about project name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ DLRN
 ====
 
 DLRN builds and maintains yum repositories following OpenStack
-uptream commit streams.
+uptream commit streams. (DLRN is not an acronym or an abbreviation,
+and it can be pronounced "dee el arr en".)
 
 Documentation is available at
 http://dlrn.readthedocs.org/en/latest/


### PR DESCRIPTION
As I was confused for a little while about the name of that project, I'm offering this bit of text as a way to resolve or defer the question.

Naturally one might assume that an all capitals set of letters is an abbreviation or acronym. This bit of text intends to resolve that question/confusion. Offering a pronunciation option is a gentle guide rather than a hard rule. With the history of the name and the way it's pronounced, I'm figuring it's easier to offer a pronunciation rather than rename the project.